### PR TITLE
Sometimes this parapmeter (portrait_banner_url) is absent.

### DIFF
--- a/library/src/main/java/net/pubnative/library/model/NativeAdModel.java
+++ b/library/src/main/java/net/pubnative/library/model/NativeAdModel.java
@@ -72,7 +72,7 @@ public class NativeAdModel extends Model implements NativeAd, TaskItemListener
     public  String                 revenue_model;
     @JSON(key = POINTS)
     public  String                 points;
-    @JSON(key = PORTRAIT_BANNER_URL)
+    @JSON(key = PORTRAIT_BANNER_URL, optional = true)
     public  String                 portraitBannerUrl;
     @JSON(key = APP_DETAILS, optional = true)
     public  AppDetailsModel        app_details;


### PR DESCRIPTION
Fix java.lang.IllegalArgumentException: Required key 'portrait_banner_url' not present.