### PR TITLE
Fix for open ad method, without a context being assigned

### DIFF
--- a/library.demo/build.gradle
+++ b/library.demo/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "net.pubnative.library.demo"
         minSdkVersion 10
         targetSdkVersion 22
-        versionCode 6
-        versionName "1.4.5"
+        versionCode 7
+        versionName "1.4.6"
     }
     buildTypes {
         release {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -6,8 +6,8 @@ android {
     defaultConfig {
         minSdkVersion 10
         targetSdkVersion 10
-        versionCode 6
-        versionName "1.4.5"
+        versionCode 7
+        versionName "1.4.6"
     }
     buildTypes {
         release {

--- a/library/src/main/java/net/pubnative/library/model/NativeAdModel.java
+++ b/library/src/main/java/net/pubnative/library/model/NativeAdModel.java
@@ -126,16 +126,24 @@ public class NativeAdModel extends Model implements NativeAd, TaskItemListener
 
     public void open(Context context)
     {
-        if (this.click_url != null)
+        this.context = context;
+        if(this.context != null)
         {
-            if (this.app_details != null && this.app_details.store_id != null)
+            if (this.click_url != null)
             {
-                this.doBackgroundRedirect();
+                if (this.app_details != null && this.app_details.store_id != null)
+                {
+                    this.doBackgroundRedirect();
+                }
+                else
+                {
+                    this.doBrowserRedirect();
+                }
             }
-            else
-            {
-                this.doBrowserRedirect();
-            }
+        }
+        else
+        {
+            Log.e("NativeAdModel", "null or invalid context assigned for opening the ad");
         }
     }
 
@@ -220,7 +228,6 @@ public class NativeAdModel extends Model implements NativeAd, TaskItemListener
     @Override
     public void onTaskItemListenerFinished(TaskItem item)
     {
-        Log.v("NativeAdModel", "onTaskItemListenerFinished");
         this.confirmBeacon(this.context, Response.NativeAd.Beacon.TYPE_IMPRESSION);
         if (this.listener != null)
         {


### PR DESCRIPTION
This patch sets the context for the methods that allows an ad to be opened, since the context wasn't being assigned as it should.