### PR TITLE
Issue 59

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ pubnative-android-library is a collection of Open Source tools to implement API 
 Add the following line to your module dependencies
 
 ```java
-compile 'net.pubnative:library:1.4.8'
+compile 'net.pubnative:library:1.4.9'
 
 ```
 
@@ -53,6 +53,17 @@ You will also need to add the following meta-data to your `AndroidManifest.xml` 
 
 <a name="usage"></a>
 # Usage
+
+First of all, ensure to add permissions `INTERNET` and `ACCESS_NETWORK_STATE` permissions to your app manifest .
+Optionally, and recommended is to add `ACCESS_COARSE_LOCATION` as shown below
+
+```xml
+<!--REQUIRED-->
+<uses-permission android:name="android.permission.INTERNET" />
+<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+<!--OPTIONAL-->
+<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
+```
 
 PubNative library is a lean yet complete library that allow you request and show ads in different ways.
 

--- a/library.demo/build.gradle
+++ b/library.demo/build.gradle
@@ -8,8 +8,8 @@ android {
         applicationId "net.pubnative.library.demo"
         minSdkVersion 10
         targetSdkVersion 22
-        versionCode 9
-        versionName "1.4.8"
+        versionCode 16
+        versionName "1.4.9"
     }
     buildTypes {
         release {

--- a/library.demo/src/main/AndroidManifest.xml
+++ b/library.demo/src/main/AndroidManifest.xml
@@ -6,7 +6,11 @@
         android:minSdkVersion="14"
         android:targetSdkVersion="21" />
 
+    <!--REQUIRED-->
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <!--OPTIONAL-->
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
 
     <application
         android:allowBackup="true"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.jfrog.bintray'
 apply plugin: 'com.github.dcendents.android-maven'
 
-version = '1.4.8'
+version = '1.4.9'
 group = 'net.pubnative'
 
 def sharedVersion = version
@@ -13,7 +13,7 @@ android {
     defaultConfig {
         minSdkVersion 10
         targetSdkVersion 10
-        versionCode 9
+        versionCode 16
         versionName sharedVersion
     }
     buildTypes {

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,10 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="net.pubnative.library">
 
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"/>
-    <application android:allowBackup="true"
-                 android:label="@string/app_name" >
-
-    </application>
+    <application/>
 
 </manifest>


### PR DESCRIPTION
This patch fixes a problem commented on issue #60 and #59 

Removing unecessary items from the library manifest to avoid conflicts and leaving ACCESS_COARSE_STATE permission as optional