### PR TITLE
Impression tracking tests

### DIFF
--- a/library/src/main/java/net/pubnative/library/request/model/PubnativeAdModel.java
+++ b/library/src/main/java/net/pubnative/library/request/model/PubnativeAdModel.java
@@ -214,7 +214,7 @@ public class PubnativeAdModel implements PubnativeImpressionTracker.Listener,
             Log.v(TAG, "startTracking - impression is already confirmed, dropping impression tracking");
         } else {
             if (mPubnativeAdTracker == null) {
-                mPubnativeAdTracker = new PubnativeImpressionTracker(view, impressionURL, this);
+                mPubnativeAdTracker = new PubnativeImpressionTracker(view, this);
             }
             mPubnativeAdTracker.startTracking();
         }

--- a/library/src/main/java/net/pubnative/library/tracking/PubnativeImpressionTracker.java
+++ b/library/src/main/java/net/pubnative/library/tracking/PubnativeImpressionTracker.java
@@ -114,7 +114,7 @@ public class PubnativeImpressionTracker {
      * @param view          ad view
      * @param listener      listener for callbacks
      */
-    public PubnativeImpressionTracker(View view, String impressionUrl, Listener listener) {
+    public PubnativeImpressionTracker(View view, Listener listener) {
 
         if (view == null) {
             Log.e(TAG, "Error: No view to track, dropping call");

--- a/library/src/main/java/net/pubnative/library/tracking/PubnativeTrackingManager.java
+++ b/library/src/main/java/net/pubnative/library/tracking/PubnativeTrackingManager.java
@@ -39,12 +39,12 @@ import java.util.List;
 
 public class PubnativeTrackingManager {
 
-    private static final String               TAG                 = PubnativeTrackingManager.class.getSimpleName();
-    private static final String               SHARED_PREFERENCES  = "net.pubnative.library.tracking.PubnativeTrackingManager";
-    private static final String               SHARED_PENDING_LIST = "pending";
-    private static final String               SHARED_FAILED_LIST  = "failed";
-    private static final long                 ITEM_VALIDITY_TIME  = 1800000; // 30 minutes
-    private static       boolean              sIsTracking         = false;
+    private    static final String               TAG                 = PubnativeTrackingManager.class.getSimpleName();
+    private    static final String               SHARED_PREFERENCES  = "net.pubnative.library.tracking.PubnativeTrackingManager";
+    protected  static final String               SHARED_PENDING_LIST = "pending";
+    protected  static final String               SHARED_FAILED_LIST  = "failed";
+    private    static final long                 ITEM_VALIDITY_TIME  = 1800000; // 30 minutes
+    private    static       boolean              sIsTracking         = false;
     //==============================================================================================
     // PUBLIC
     //==============================================================================================

--- a/library/src/test/java/net/pubnative/library/tracking/PubnativeImpressionTrackerTest.java
+++ b/library/src/test/java/net/pubnative/library/tracking/PubnativeImpressionTrackerTest.java
@@ -1,0 +1,52 @@
+package net.pubnative.library.tracking;
+
+import android.content.Context;
+import android.view.View;
+
+import net.pubnative.library.BuildConfig;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class,
+        sdk = 21)
+public class PubnativeImpressionTrackerTest {
+
+    Context applicationContext;
+
+    @Before
+    public void setUp() {
+
+        this.applicationContext = RuntimeEnvironment.application.getApplicationContext();
+    }
+
+    @Test
+    public void testWithValidListener() {
+
+        PubnativeImpressionTracker.Listener listener = spy(PubnativeImpressionTracker.Listener.class);
+        View adView = spy(new View(applicationContext));
+        PubnativeImpressionTracker impressionTracker = spy(new PubnativeImpressionTracker(adView, listener));
+
+        impressionTracker.invokeOnTrackerImpression();
+        verify(listener, times(1)).onImpressionDetected(eq(adView));
+    }
+
+    @Test
+    public void testWithNullListener() {
+
+        View adView = spy(new View(applicationContext));
+        PubnativeImpressionTracker impressionTracker = spy(new PubnativeImpressionTracker(adView, null));
+
+        impressionTracker.invokeOnTrackerImpression();
+    }
+}

--- a/library/src/test/java/net/pubnative/library/tracking/PubnativeTrackingManagerTest.java
+++ b/library/src/test/java/net/pubnative/library/tracking/PubnativeTrackingManagerTest.java
@@ -45,7 +45,7 @@ public class PubnativeTrackingManagerTest {
         PubnativeTrackingManager.track(applicationContext, "");
         List<PubnativeTrackingURLModel> urlModelList = PubnativeTrackingManager.getList(applicationContext, PubnativeTrackingManager.SHARED_PENDING_LIST);
 
-        Assert.assertTrue(urlModelList.size() == 0);
+        assertThat(urlModelList).isEmpty();
     }
 
     @Test

--- a/library/src/test/java/net/pubnative/library/tracking/PubnativeTrackingManagerTest.java
+++ b/library/src/test/java/net/pubnative/library/tracking/PubnativeTrackingManagerTest.java
@@ -1,0 +1,78 @@
+package net.pubnative.library.tracking;
+
+import android.content.Context;
+
+import junit.framework.Assert;
+
+import net.pubnative.library.BuildConfig;
+import net.pubnative.library.tracking.model.PubnativeTrackingURLModel;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import java.util.List;
+
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class,
+        sdk = 21)
+public class PubnativeTrackingManagerTest {
+
+    Context applicationContext;
+
+    @Before
+    public void setUp() {
+
+        this.applicationContext = RuntimeEnvironment.application.getApplicationContext();
+    }
+
+    @Test
+    public void testWithNullContext() {
+
+        PubnativeTrackingManager.track(null, "www.google.com");
+    }
+
+    @Test
+    public void testWithEmptyUrl() {
+
+        PubnativeTrackingManager.track(applicationContext, "");
+        List<PubnativeTrackingURLModel> urlModelList = PubnativeTrackingManager.getList(applicationContext, "pending");
+
+        Assert.assertTrue(urlModelList.size() == 0);
+    }
+
+    @Test
+    public void checkItemEnqued() {
+
+        PubnativeTrackingManager.setList(applicationContext, "pending", null);
+
+        PubnativeTrackingURLModel model = new PubnativeTrackingURLModel();
+        model.url = "www.google.com";
+        model.startTimestamp = System.currentTimeMillis();
+
+        PubnativeTrackingManager.enqueueItem(applicationContext, "pending", model);
+
+        List<PubnativeTrackingURLModel> urlModelList = PubnativeTrackingManager.getList(applicationContext, "pending");
+
+        Assert.assertTrue(urlModelList.size() > 0);
+    }
+
+    @Test
+    public void checkItemdDequeued() {
+
+        PubnativeTrackingManager.setList(applicationContext, "pending", null);
+
+        PubnativeTrackingURLModel model = new PubnativeTrackingURLModel();
+        model.url = "www.google.com";
+        model.startTimestamp = System.currentTimeMillis();
+
+        PubnativeTrackingManager.enqueueItem(applicationContext, "pending", model);
+
+        PubnativeTrackingURLModel dequedItem = PubnativeTrackingManager.dequeueItem(applicationContext, "pending");
+
+        Assert.assertTrue(model.url.equalsIgnoreCase(dequedItem.url) && model.startTimestamp == dequedItem.startTimestamp);
+    }
+}


### PR DESCRIPTION
This includes:

- Simplified constructor of `PubnativeImpressionTracker` by removing unnecessary impressionUrl in constructor 
- Tests for `PubnativeImpressionTracker` & `PubnativeTrackingManager`