### PR TITLE
starting activity from application context instead of view context

### DIFF
--- a/library/src/main/java/net/pubnative/library/request/model/PubnativeAdModel.java
+++ b/library/src/main/java/net/pubnative/library/request/model/PubnativeAdModel.java
@@ -261,7 +261,7 @@ public class PubnativeAdModel implements PubnativeImpressionTracker.Listener,
             try {
                 Uri uri = Uri.parse(urlString);
                 Intent intent = new Intent(Intent.ACTION_VIEW, uri);
-                mClickableView.getContext().startActivity(intent);
+                mClickableView.getContext().getApplicationContext().startActivity(intent);
                 invokeOnOpenOffer();
             } catch (Exception ex) {
                 Log.e(TAG, "openURL: Error - " + ex.getMessage());


### PR DESCRIPTION
Changes:

This patch is meant to fix #71 

So I'm getting application context to open a new activity instead of using the given view context (which can be initialised at other moment)