### PR TITLE
avoid starting twice the impression tracking thread

### DIFF
--- a/library/src/main/java/net/pubnative/library/tracking/PubnativeImpressionTracker.java
+++ b/library/src/main/java/net/pubnative/library/tracking/PubnativeImpressionTracker.java
@@ -158,17 +158,17 @@ public class PubnativeImpressionTracker {
         }
     };
 
-    private void checkImpression() {
+    private synchronized void checkImpression() {
 
         if (mIsTrackingInProgress || mTrackingShouldStop) {
             return;
         }
         if (SystemUtils.isVisibleOnScreen(mView, VISIBILITY_PERCENTAGE_THRESHOLD)) {
-            mIsTrackingInProgress = true;
             if (mCheckImpressionThread == null) {
+                mIsTrackingInProgress = true;
                 mCheckImpressionThread = new Thread(new CheckImpressionRunnable());
+                mCheckImpressionThread.start();
             }
-            mCheckImpressionThread.start();
         }
     }
 


### PR DESCRIPTION
Related to #77 

This patch sets a synchronized tag in the `checkImpression` method that is invoked by 2 automate threads and can lead to the detailed error. It also starts the thread only when it's created, so it has to be stopped in order to be restarted avoiding calling `start` twice

