### PR TITLE
Moved load parameters to load method instead of constructor

### DIFF
--- a/library.demo/src/main/java/net/pubnative/library/demo/InterstitialAdActivity.java
+++ b/library.demo/src/main/java/net/pubnative/library/demo/InterstitialAdActivity.java
@@ -27,9 +27,9 @@ public class InterstitialAdActivity extends Activity implements PubnativeInterst
 
         Log.v(TAG, "onRequestClick");
         mLoaderContainer.setVisibility(View.VISIBLE);
-        PubnativeInterstitial interstitial = new PubnativeInterstitial(this, Settings.getAppToken());
+        PubnativeInterstitial interstitial = new PubnativeInterstitial();
         interstitial.setListener(this);
-        interstitial.load();
+        interstitial.load(this, Settings.getAppToken());
     }
 
     //==============================================================================================

--- a/library.interstitial/src/main/java/net/pubnative/library/interstitial/PubnativeInterstitial.java
+++ b/library.interstitial/src/main/java/net/pubnative/library/interstitial/PubnativeInterstitial.java
@@ -89,44 +89,6 @@ public class PubnativeInterstitial implements PubnativeRequest.Listener,
         void onPubnativeInterstitialHide(PubnativeInterstitial interstitial);
     }
 
-    public PubnativeInterstitial(Context context, String appToken) {
-
-        mContext = context;
-        mAppToken = appToken;
-        mWindowManager = (WindowManager) mContext.getSystemService(Context.WINDOW_SERVICE);
-        LayoutInflater layoutInflater = (LayoutInflater) mContext.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
-        RelativeLayout interstitial = (RelativeLayout) layoutInflater.inflate(R.layout.pubnative_interstitial, null);
-        mTitle = (TextView) interstitial.findViewById(R.id.pubnative_interstitial_title);
-        mDescription = (TextView) interstitial.findViewById(R.id.pubnative_interstitial_description);
-        mIcon = (ImageView) interstitial.findViewById(R.id.pn_interstitial_icon);
-        mBanner = (ImageView) interstitial.findViewById(R.id.pubnative_interstitial_banner);
-        mRating = (RatingBar) interstitial.findViewById(R.id.pubnative_interstitial_rating);
-        mCTA = (TextView) interstitial.findViewById(R.id.pubnative_interstitial_cta);
-        mContainer = new RelativeLayout(mContext) {
-
-            @Override
-            public boolean dispatchKeyEvent(KeyEvent event) {
-
-                Log.v(TAG, "dispatchKeyEvent");
-                if (event.getKeyCode() == KeyEvent.KEYCODE_BACK) {
-                    hide();
-                    return true;
-                }
-                return super.dispatchKeyEvent(event);
-            }
-
-            @Override
-            protected void onWindowVisibilityChanged(int visibility) {
-
-                Log.v(TAG, "onWindowVisibilityChanged");
-                if (visibility != View.VISIBLE) {
-                    hide();
-                }
-            }
-        };
-        mContainer.addView(interstitial);
-    }
-
     /**
      * Sets a callback listener for this interstitial object
      *
@@ -141,20 +103,23 @@ public class PubnativeInterstitial implements PubnativeRequest.Listener,
     /**
      * Starts loading an ad for this interstitial
      */
-    public void load() {
+    public void load(Context context, String appToken) {
 
         Log.v(TAG, "load");
-        if (TextUtils.isEmpty(mAppToken)) {
+        if (TextUtils.isEmpty(appToken)) {
             invokeLoadFail(new Exception("PubnativeInterstitial - load error: app token is null or empty"));
-        } else if (mContext == null) {
+        } else if (context == null) {
             invokeLoadFail(new Exception("PubnativeInterstitial - load error: context is null or empty"));
         } else if (mIsLoading) {
             Log.w(TAG, "load - The ad is loaded or being loaded, dropping this call");
         } else if (isReady()) {
             invokeLoadFinish();
         } else {
+            mContext = context;
+            mAppToken = appToken;
             mIsShown = false;
             mIsLoading = true;
+            initialize();
             PubnativeRequest request = new PubnativeRequest();
             request.setParameter(PubnativeRequest.Parameters.APP_TOKEN, mAppToken);
             String[] assets = new String[] {
@@ -207,7 +172,6 @@ public class PubnativeInterstitial implements PubnativeRequest.Listener,
         mIsShown = false;
         mIsLoading = false;
     }
-
     //==============================================================================================
     // Helpers
     //==============================================================================================
@@ -242,6 +206,42 @@ public class PubnativeInterstitial implements PubnativeRequest.Listener,
         mWindowManager.addView(mContainer, params);
         mAdModel.startTracking(mContainer, mCTA, this);
         invokeShow();
+    }
+
+    protected void initialize() {
+
+        mWindowManager = (WindowManager) mContext.getSystemService(Context.WINDOW_SERVICE);
+        LayoutInflater layoutInflater = (LayoutInflater) mContext.getSystemService(Context.LAYOUT_INFLATER_SERVICE);
+        RelativeLayout interstitial = (RelativeLayout) layoutInflater.inflate(R.layout.pubnative_interstitial, null);
+        mTitle = (TextView) interstitial.findViewById(R.id.pubnative_interstitial_title);
+        mDescription = (TextView) interstitial.findViewById(R.id.pubnative_interstitial_description);
+        mIcon = (ImageView) interstitial.findViewById(R.id.pn_interstitial_icon);
+        mBanner = (ImageView) interstitial.findViewById(R.id.pubnative_interstitial_banner);
+        mRating = (RatingBar) interstitial.findViewById(R.id.pubnative_interstitial_rating);
+        mCTA = (TextView) interstitial.findViewById(R.id.pubnative_interstitial_cta);
+        mContainer = new RelativeLayout(mContext) {
+
+            @Override
+            public boolean dispatchKeyEvent(KeyEvent event) {
+
+                Log.v(TAG, "dispatchKeyEvent");
+                if (event.getKeyCode() == KeyEvent.KEYCODE_BACK) {
+                    hide();
+                    return true;
+                }
+                return super.dispatchKeyEvent(event);
+            }
+
+            @Override
+            protected void onWindowVisibilityChanged(int visibility) {
+
+                Log.v(TAG, "onWindowVisibilityChanged");
+                if (visibility != View.VISIBLE) {
+                    hide();
+                }
+            }
+        };
+        mContainer.addView(interstitial);
     }
 
     //==============================================================================================
@@ -299,7 +299,6 @@ public class PubnativeInterstitial implements PubnativeRequest.Listener,
             mListener.onPubnativeInterstitialHide(this);
         }
     }
-
     //==============================================================================================
     // Callbacks
     //==============================================================================================
@@ -324,7 +323,6 @@ public class PubnativeInterstitial implements PubnativeRequest.Listener,
         Log.v(TAG, "onPubnativeRequestFailed");
         invokeLoadFail(ex);
     }
-
     //----------------------------------------------------------------------------------------------
     // PubnativeAdModel.Listener
     //----------------------------------------------------------------------------------------------


### PR DESCRIPTION
This patch contains a fix to avoid fixing the app token and context on the creation of the interstitial object letting it to be reused with different apptoken and load afterwards