### PR TITLE
Remove strings.xml file to avoid conflicts

### DIFF
--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">pubnative-android-library</string>
-</resources>


### PR DESCRIPTION
PubNative library defines the string "app_name" and this, under some circumstances, may cause a conflict if the app also defines (and uses) this string. It would be better to just remove the file from the library.