### PR TITLE
removed useless app_name

### DIFF
--- a/library.feed.banner/src/main/res/values/strings.xml
+++ b/library.feed.banner/src/main/res/values/strings.xml
@@ -1,4 +1,3 @@
 <resources>
-    <string name="app_name">In-feed banner</string>
     <string name="pubnative_interstitial_sponsored_text">sponsored</string>
 </resources>

--- a/library/src/main/res/values/strings.xml
+++ b/library/src/main/res/values/strings.xml
@@ -1,3 +1,0 @@
-<resources>
-    <string name="app_name">pubnative-android-library</string>
-</resources>


### PR DESCRIPTION
Related to #107  

This patch removes unnecessary app_name strings in the modules to avoid confusion