### PR TITLE
loadingView's parent may not be the getRootView()

### DIFF
--- a/library/src/main/java/net/pubnative/library/request/model/PubnativeAdModel.java
+++ b/library/src/main/java/net/pubnative/library/request/model/PubnativeAdModel.java
@@ -797,8 +797,9 @@ public class PubnativeAdModel implements PubnativeImpressionTracker.Listener,
         Log.v(TAG, "hideLoadingView");
         if (getRootView() == null) {
             Log.w(TAG, "hideLoadingView - Error: impossible to retrieve root view");
-        } else {
-            getRootView().removeView(getLoadingView());
+        }
+        if (getLoadingView().getParent()!=null){
+            ((ViewGroup)getLoadingView().getParent()).removeView(getLoadingView());
         }
     }
 


### PR DESCRIPTION
we use the same model, but in different parent, it crashes.